### PR TITLE
Support passing a timeout to requests.get()

### DIFF
--- a/censusgeocode/censusgeocode.py
+++ b/censusgeocode/censusgeocode.py
@@ -51,7 +51,7 @@ class CensusGeocode(object):
         returntype = returntype or self.returntypes[0]
         return self._url.format(returntype=returntype, searchtype=searchtype)
 
-    def _fetch(self, searchtype, fields, layers=None, returntype=None):
+    def _fetch(self, searchtype, fields, layers=None, returntype=None, timeout=None):
         fields['vintage'] = self.vintage
         fields['benchmark'] = self.benchmark
         fields['format'] = 'json'
@@ -64,7 +64,7 @@ class CensusGeocode(object):
         url = self._geturl(searchtype, returntype)
 
         try:
-            response = requests.get(url, params=fields)
+            response = requests.get(url, params=fields, timeout=timeout)
             return CensusResult(response.json())
 
         except (ValueError, KeyError):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except IOError:
 
 setup(
     name='censusgeocode',
-    version='0.2.3',
+    version='0.2.4',
     description='Thin Python wrapper for the US Census Geocoder',
     long_description=readme,
     keywords='census geocode api',


### PR DESCRIPTION
We'd like to use this library with a custom timeout. We're hoping to change the API to pass an optional timeout from the `kwargs` of `coordinates()` into `_fetch()`