### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ python:
     - 3.6
 
 before_install:
-    - pip install coverage
+    - pip install --upgrade coverage setuptools
 
 install:
     - python setup.py install


### PR DESCRIPTION
Trying out the suggestion in https://github.com/pyexcel/pyexcel/issues/49

The error I'm fixing is:

```
Installed /tmp/easy_install-2n7kao/cryptography-2.1.2/.eggs/pycparser-2.18-py3.3.egg
error: Setup script exited with error in cryptography setup command: Invalid environment marker: platform_python_implementation != 'PyPy'
```