### PR TITLE
Convert BytesIO() to StringIO()

### DIFF
--- a/censusgeocode/censusgeocode.py
+++ b/censusgeocode/censusgeocode.py
@@ -165,8 +165,8 @@ class CensusGeocode(object):
         url = self._geturl('addressbatch', returntype)
 
         if data is not None:
-            # compile data into a BytesIO
-            f = io.BytesIO()
+            # For Python 3, compile data into a StringIO
+            f = io.StringIO()
             writer = csv.DictWriter(f, fieldnames=['id', 'street', 'city', 'state', 'zip'])
             for i, row in enumerate(data):
                 row.setdefault('id', i)


### PR DESCRIPTION
Dear Maintainer,

I've encountered a lingering issue regarding the conversion from Python 2 to 3.  

Here is some sample data:
```python
from censusgeocode import addressbatch
from pandas import DataFrame

# Generic Data
sample = DataFrame(
    data={
        'id': (range(3)),
        'street': ('1 Arena Plaza', 'One Symphony Place',
                   '500 South Capitol Avenue'),
        'city': ('Louisville', 'Nashville', 'Indianapolis'),
        'state': ('KY', 'TN', 'IN'),
        'zip': ('40202', '37201', '46225')
    })

# Running this line causes an error.  Docs and comments say it should work.
addressbatch(sample.to_dict(orient='records'))
```

When calling `addressbatch()` on a list of dicts, the following error results:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
 in 
      1 # %%
----> 2 addressbatch(sample.to_dict(orient='records'))
      3 
      4 # # %% Drop NaNs before sending to API
      5 # to_census_api = active_termed_ee["geo"].dropna()

~/.local/miniconda3/lib/python3.7/site-packages/censusgeocode/censusgeocode.py in addressbatch(self, data, **kwargs)
    215         else:
    216             # Otherwise, assume a list of dicts
--> 217             return self._post_batch(data=data, **kwargs)
    218 
    219 

~/.local/miniconda3/lib/python3.7/site-packages/censusgeocode/censusgeocode.py in _post_batch(self, data, f, **kwargs)
    172             for i, row in enumerate(data):
    173                 row.setdefault('id', i)
--> 174                 writer.writerow(row)
    175 
    176             f.seek(0)

~/.local/miniconda3/lib/python3.7/csv.py in writerow(self, rowdict)
    153 
    154     def writerow(self, rowdict):
--> 155         return self.writer.writerow(self._dict_to_list(rowdict))
    156 
    157     def writerows(self, rowdicts):

TypeError: a bytes-like object is required, not 'str'
```

The solution is rather simple.  By changing `BytesIO()` to `StringIO()` in function `_post_batch`, the issue goes away.   Making this modification and running again results in the desired output:

```
[OrderedDict([('id', '0'),
              ('address', '1 Arena Plaza, Louisville, KY, 40202'),
              ('match', False),
              ('matchtype', None),
              ('parsed', None),
              ('tigerlineid', None),
              ('side', None),
              ('statefp', None),
              ('countyfp', None),
              ('tract', None),
              ('block', None),
              ('lat', None),
              ('lon', None)]),
 OrderedDict([('id', '1'),
              ('address', 'One Symphony Place, Nashville, TN, 37201'),
              ('match', False),
              ('matchtype', None),
              ('parsed', None),
              ('tigerlineid', None),
              ('side', None),
              ('statefp', None),
              ('countyfp', None),
              ('tract', None),
              ('block', None),
              ('lat', None),
              ('lon', None)]),
 OrderedDict([('id', '2'),
              ('address', '500 South Capitol Avenue, Indianapolis, IN, 46225'),
              ('match', True),
              ('matchtype', 'Exact'),
              ('parsed', '500 S CAPITOL AVE, INDIANAPOLIS, IN, 46225'),
              ('tigerlineid', '108068009'),
              ('side', 'R'),
              ('statefp', '18'),
              ('countyfp', '097'),
              ('tract', '391000'),
              ('block', '3138'),
              ('lon', -86.16203),
              ('lat', 39.75886)])]
```