### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Or from stdin, using `-` as the filename:
 cat tests/fixtures/batch.csv | censusgeocode --csv -
 ````
 
-According to the Census docs, the batch geocoder is limited to 1000 rows.
+According to the Census docs, the batch geocoder is limited to 10,000 rows.
 
 The output will be a CSV file (with a header) and the columns:
 * id


### PR DESCRIPTION
The batch geocoder can handle 10,000 rows according to the [Census documentation](https://www.census.gov/programs-surveys/geography/technical-documentation/complete-technical-documentation/census-geocoder.html), not 1,000:

> The batch geocoder can process up to 10,000 addresses at a time. It may take several minutes to process this many addresses.