### PR TITLE
Allow "zipcode" in addressbatch()

### DIFF
--- a/censusgeocode/censusgeocode.py
+++ b/censusgeocode/censusgeocode.py
@@ -193,7 +193,7 @@ class CensusGeocode:
         with io.StringIO(data) as f:
             reader = csv.DictReader(f, fieldnames=fieldnames)
             return [parse(row) for row in reader]
-    
+
     def _post_batch(self, data=None, f=None, **kwargs):
         """Send batch address file to the Census Geocoding API"""
         returntype = kwargs.get("returntype", "geographies")
@@ -235,10 +235,13 @@ class CensusGeocode:
     def addressbatch(self, data, **kwargs):
         """
         Send either a CSV file or data to the addressbatch API.
-        According to the Census, "there is currently an upper limit of 1000 records per batch file."
-        If a file, must have no header and fields id,street,city,state,zip
-        If data, should be an iterable of dicts with the above fields (although ID is optional,
-        and you can use "zipcode" instead of "zip".)
+        
+        According to the Census, "there is currently an upper limit of 10,000 records per batch file."
+        
+        If a file, can either be a file-like with a `read()` method, or a `str` that's a path to the
+        file. Either way, it must have no header and have fields id,street,city,state,zip
+        
+        If data, should be an iterable of dicts with the above fields (although ID is optional).
         """
         # Does data quack like a file handle?
         if hasattr(data, "read"):

--- a/censusgeocode/censusgeocode.py
+++ b/censusgeocode/censusgeocode.py
@@ -124,10 +124,10 @@ class CensusGeocode:
     def address(self, street, city=None, state=None, zipcode=None, zip=None, **kwargs):
         """Geocode an address."""
         if "zipcode" is not None:
-            warnings.warn(DeprecationWarning("'zipcode' is deprecated. Use 'zip' instead."))
             if "zip" is not None:
                 raise ValueError("Only one of 'zipcode' or 'zip' can be used.")
-        zip = zipcode
+            warnings.warn(DeprecationWarning("'zipcode' is deprecated. Use 'zip' instead."))
+            zip = zipcode
         fields = {
             "street": street,
             "city": city,


### PR DESCRIPTION
Currently, the `address()` function expects the keyword argument "zipcode". However, the `addressbatch()` function, if you use the iterable-of-dicts form of argument, expects each dict to have the key "zip". This makes it so users of this library have to use two different schemas, "zip" in one place and "zipcode" in another, depending on if they use `address()` or `addressbatch()`.

This tweaks `addressbatch()` so if you use an iterable-of-dicts, you can use the key "zipcode" instead of "zip". Now in my user code, I only need to have one schema, the one with "zipcode".

This change *doe not* affect `addressbatch()` when you pass in a CSV file. One, I didn't see an easy way to fix this (first thought would be to wrap the file-like-object in a custom file-like-object that modifies the contents on every call to `read()`). Two, I'd imagine the need isn't as serious here, because if you're using a file-like-object then I'd think that you wouldn't even be writing the code that formats that data.