### PR TITLE
Fixed Urllib error (Issue #29)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 packages = find:
 install_requires = 
 	requests[security]>=2.27.0,<3
-    requests-toolbelt>=0.9.0,<1
+    requests-toolbelt>=0.9.0 # removed version restriction to be less than 1
 python_requires = >= 3.6, <4
 
 [options.extras_require]


### PR DESCRIPTION
Library was giving urllib errors for python > 3.9
Error was (similar error in python 3.11.9)
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/requests_toolbelt/_compat.py", line 48, in <module>
    from requests.packages.urllib3.contrib import appengine as gaecontrib
ImportError: cannot import name 'appengine' from 'requests.packages.urllib3.contrib' (/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/urllib3/contrib/__init__.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/runner/work/censusgeocode-test/censusgeocode-test/tests/__init__.py", line 10, in <module>
    from . import test_censusgeocode
  File "/home/runner/work/censusgeocode-test/censusgeocode-test/tests/test_censusgeocode.py", line 14, in <module>
    from censusgeocode import CensusGeocode
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/censusgeocode/__init__.py", line 10, in <module>
    from .censusgeocode import CensusGeocode
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/censusgeocode/censusgeocode.py", line 26, in <module>
    from requests_toolbelt.multipart.encoder import MultipartEncoder
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/requests_toolbelt/__init__.py", line 12, in <module>
    from .adapters import SSLAdapter, SourceAddressAdapter
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/requests_toolbelt/adapters/__init__.py", line 12, in <module>
    from .ssl import SSLAdapter
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/requests_toolbelt/adapters/ssl.py", line 16, in <module>
    from .._compat import poolmanager
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/requests_toolbelt/_compat.py", line 50, in <module>
    from urllib3.contrib import appengine as gaecontrib
ImportError: cannot import name 'appengine' from 'urllib3.contrib' (/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/urllib3/contrib/__init__.py)
```
Allowed requests-toolbelt > 0.9.0 be allowed. requests-toolbelt 1.0.0 fixes the issue.