### PR TITLE
Fix and Update Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,15 @@ on:
   release:
     types: [created]
 
+permissions: read-all
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,14 +19,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: setup.cfg
 
       - name: Install build requirements
-        run: |
-          python -m pip install -U pip
-          pip install build
+        run: pip install build
 
       - run: make build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
   push:
   pull_request:
     branches: [master]
+  schedule:
+    - cron: 0 0 * * 1
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ on:
     - cron: 0 0 * * 1
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11.9"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11.9"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,23 @@ permissions: read-all
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,13 @@ name: Test package
 
 on:
   push:
+    branches:
+      - master
+      - main
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - main
   schedule:
     - cron: 0 0 * * 1
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,6 @@ jobs:
           cache-dependency-path: setup.cfg
 
       - name: Install package
-        run: |
-          python -m pip install -U pip
-          pip install '.[tests]'
+        run: pip install '.[test]'
 
       - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ permissions: read-all
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python:
           - '3.7'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version:
+        python:
           - '3.7'
           - '3.8'
           - '3.9'

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,7 @@
+0.5.3
+-----
+* Remove upper version limits on requests-toolbelt, requests, and vcrpy (used only for testing)
+
 0.5.2
 -----
 * Accept either "zip" or "zipcode" as an argument in `CensusGeocode.address` (#24).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-Census Geocode
+[![Test package](https://github.com/fitnr/censusgeocode/actions/workflows/test.yml/badge.svg)](https://github.com/fitnr/censusgeocode/actions/workflows/test.yml)
+
+# Census Geocode
+
 --------------
 
 Census Geocode is a light weight Python wrapper for the US Census [Geocoder API](http://geocoding.geo.census.gov/geocoder/), compatible with  Python 3. It comes packaged with a simple command line tool for geocoding an address to a longitude and latitude, or a batch file into a parsed address and coordinates.
@@ -95,7 +98,7 @@ Queries return a CensusResult object, which is basically a Python list with an e
 }]
 ```
 
-### Advanced
+## Advanced
 
 By default, the geocoder uses the "Current" vintage and benchmarks. To use another vintage or benchmark, use the `CensusGeocode` class:
 ````python

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 # Census Geocode
 
---------------
-
 Census Geocode is a light weight Python wrapper for the US Census [Geocoder API](http://geocoding.geo.census.gov/geocoder/), compatible with  Python 3. It comes packaged with a simple command line tool for geocoding an address to a longitude and latitude, or a batch file into a parsed address and coordinates.
 
 It's strongly recommended to review the [Census Geocoder docs](https://www.census.gov/programs-surveys/geography/technical-documentation/complete-technical-documentation/census-geocoder.html) before using this module.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [metadata]
-license_files = LICENSE.txt
+license_files = LICENSE
 name = censusgeocode
 version = attr: censusgeocode.__version__
 description = Thin Python wrapper for the US Census Geocoder

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 install_requires = 
 	requests[security]>=2.27
     requests-toolbelt>=0.9
-python_requires = >=3.6,<4
+python_requires = >=3.8,<4
 
 [options.extras_require]
 test = vcrpy>=4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,12 @@ package_dir =
     =src
 packages = find:
 install_requires = 
-	requests[security]>=2.27.0
-    requests-toolbelt>=0.9.0
+	requests[security]>=2.27
+    requests-toolbelt>=0.9
 python_requires = >=3.6,<4
 
 [options.extras_require]
-tests = vcrpy>=4.1.1
+test = vcrpy>=4.1
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,10 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Operating System :: OS Independent
 
 [options]
@@ -27,12 +31,12 @@ package_dir =
     =src
 packages = find:
 install_requires = 
-	requests[security]>=2.27.0,<3
-    requests-toolbelt>=0.9.0 # removed version restriction to be less than 1
-python_requires = >= 3.6, <4
+	requests[security]>=2.27.0
+    requests-toolbelt>=0.9.0
+python_requires = >=3.6,<4
 
 [options.extras_require]
-tests = vcrpy>=4.1.1,<5
+tests = vcrpy>=4.1.1
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ python_requires = >=3.6,<4
 
 [options.extras_require]
 test = vcrpy>=4.1
+tests = vcrpy>=4.1
 
 [options.packages.find]
 where = src

--- a/src/censusgeocode/__init__.py
+++ b/src/censusgeocode/__init__.py
@@ -9,7 +9,7 @@
 
 from .censusgeocode import CensusGeocode
 
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 
 cg = CensusGeocode()
 


### PR DESCRIPTION
The last Action that ran on this repo failed.
- This PR adds testing on each major os and changes python test versions to 3.8-3.14 (as 3.7 is no longer available on ubuntu and macos runners)
- Remove upper version limits on requests-toolbelt, requests, and vcrpy (used only for testing)
- Bump version number and add changes to changelog to prepare for release to fix issues with modern (secure) versions of urllib3